### PR TITLE
Fix Beastmaster notifications and spawn protection

### DIFF
--- a/src/main/java/com/maks/myexperienceplugin/Class/skills/AscendancySkillEffectIntegrator.java
+++ b/src/main/java/com/maks/myexperienceplugin/Class/skills/AscendancySkillEffectIntegrator.java
@@ -155,7 +155,7 @@ public class AscendancySkillEffectIntegrator implements Listener {
 
                     for (Player player : Bukkit.getOnlinePlayers()) {
                         String ascendancy = plugin.getClassManager().getPlayerAscendancy(player.getUniqueId());
-                        if ("Beastmaster".equals(ascendancy)) {
+                        if ("Beastmaster".equalsIgnoreCase(ascendancy)) {
                             handler.checkAndSummonCreatures(player);
                         }
                     }
@@ -304,7 +304,7 @@ public class AscendancySkillEffectIntegrator implements Listener {
         String ascendancy = plugin.getClassManager().getPlayerAscendancy(player.getUniqueId());
 
         // Handle summon commands for Beastmaster
-        if ("Beastmaster".equals(ascendancy) && label.equalsIgnoreCase("summon")) {
+        if ("Beastmaster".equalsIgnoreCase(ascendancy) && label.equalsIgnoreCase("summon")) {
             if (args.length < 1) {
                 player.sendMessage("§cUsage: /summon <wolf|boar|bear>");
                 return true;

--- a/src/main/java/com/maks/myexperienceplugin/Class/skills/PlayerSkillEffectsListener.java
+++ b/src/main/java/com/maks/myexperienceplugin/Class/skills/PlayerSkillEffectsListener.java
@@ -42,7 +42,7 @@ public class PlayerSkillEffectsListener implements Listener {
 
             // Add this block: Check for Beastmaster and trigger summons
             String ascendancy = plugin.getClassManager().getPlayerAscendancy(player.getUniqueId());
-            if ("Beastmaster".equals(ascendancy)) {
+            if ("Beastmaster".equalsIgnoreCase(ascendancy)) {
                 plugin.getLogger().info("[BEASTMASTER DEBUG] Checking for auto-summons for " + player.getName());
                 BeastmasterSkillEffectsHandler handler = 
                     (BeastmasterSkillEffectsHandler) plugin.getAscendancySkillEffectIntegrator().getHandler("Beastmaster");

--- a/src/main/java/com/maks/myexperienceplugin/Class/skills/SkillEffectsHandler.java
+++ b/src/main/java/com/maks/myexperienceplugin/Class/skills/SkillEffectsHandler.java
@@ -106,7 +106,7 @@ public class SkillEffectsHandler implements Listener {
         }
         
         // Check and summon creatures for Beastmaster on join
-        if ("Beastmaster".equals(ascendancy)) {
+        if ("Beastmaster".equalsIgnoreCase(ascendancy)) {
             // Schedule summon check after a short delay to ensure player is fully loaded
             Bukkit.getScheduler().runTaskLater(plugin, () -> {
                 if (player.isOnline()) {
@@ -141,7 +141,7 @@ public class SkillEffectsHandler implements Listener {
         }
         
         // Add Beastmaster cleanup
-        if ("Beastmaster".equals(ascendancy)) {
+        if ("Beastmaster".equalsIgnoreCase(ascendancy)) {
             BaseSkillEffectsHandler handler = classHandlers.get(ascendancy);
             if (handler instanceof com.maks.myexperienceplugin.Class.skills.effects.ascendancy.BeastmasterSkillEffectsHandler) {
                 com.maks.myexperienceplugin.Class.skills.effects.ascendancy.BeastmasterSkillEffectsHandler beastHandler = 
@@ -333,7 +333,7 @@ public class SkillEffectsHandler implements Listener {
         }
         
         // Check for Beastmaster Bear Guardian
-        if ("Beastmaster".equals(ascendancy)) {
+        if ("Beastmaster".equalsIgnoreCase(ascendancy)) {
             BaseSkillEffectsHandler handler = classHandlers.get(ascendancy);
             if (handler != null && handler instanceof BeastmasterSkillEffectsHandler) {
                 BeastmasterSkillEffectsHandler beastHandler = (BeastmasterSkillEffectsHandler) handler;
@@ -375,8 +375,12 @@ public class SkillEffectsHandler implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+
         if (!(event.getDamager() instanceof Player)) {
             return;
         }

--- a/src/main/java/com/maks/myexperienceplugin/Class/skills/SkillTreeManager.java
+++ b/src/main/java/com/maks/myexperienceplugin/Class/skills/SkillTreeManager.java
@@ -671,7 +671,7 @@ public class SkillTreeManager {
         Set<Integer> purchasedSkills = getPurchasedSkills(uuid);
 
         // Special check for Beastmaster summon skills
-        if ("Beastmaster".equals(ascendancy)) {
+        if ("Beastmaster".equalsIgnoreCase(ascendancy)) {
             // Check if this is one of the summon skills (Wolf, Boar, Bear)
             if (skillId == 100001 || skillId == 100002 || skillId == 100003) {
                 // If player already has this skill, allow the purchase (for upgrades)

--- a/src/main/java/com/maks/myexperienceplugin/Class/skills/effects/ascendancy/BeastmasterSkillEffectsHandler.java
+++ b/src/main/java/com/maks/myexperienceplugin/Class/skills/effects/ascendancy/BeastmasterSkillEffectsHandler.java
@@ -5,6 +5,7 @@ import com.maks.myexperienceplugin.Class.skills.effects.BaseSkillEffectsHandler;
 import com.maks.myexperienceplugin.MyExperiencePlugin;
 import com.maks.myexperienceplugin.utils.ActionBarUtils;
 import com.maks.myexperienceplugin.utils.DebugUtils;
+import com.maks.myexperienceplugin.utils.ChatNotificationUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Particle;
@@ -179,7 +180,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
                 // This is handled when player uses the summon command
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 1: Wolf summon unlocked for " + player.getName());
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 1: Wolf summon unlocked (50 dmg/50 hp)");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 1: Wolf summon unlocked (50 dmg/50 hp)");
                 }
                 // DODAJ TĘ LINIĘ:
                 Bukkit.getScheduler().runTaskLater(plugin, () -> checkAndSummonCreatures(player), 20L);
@@ -188,7 +189,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
                 // This is handled when player uses the summon command
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 2: Boar summon unlocked for " + player.getName());
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 2: Boar summon unlocked (80 dmg/20 hp)");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 2: Boar summon unlocked (80 dmg/20 hp)");
                 }
                 // DODAJ TĘ LINIĘ:
                 Bukkit.getScheduler().runTaskLater(plugin, () -> checkAndSummonCreatures(player), 20L);
@@ -197,7 +198,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
                 // This is handled when player uses the summon command
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 3: Bear summon unlocked for " + player.getName());
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 3: Bear summon unlocked (20 dmg/80 hp)");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 3: Bear summon unlocked (20 dmg/80 hp)");
                 }
                 // DODAJ TĘ LINIĘ:
                 Bukkit.getScheduler().runTaskLater(plugin, () -> checkAndSummonCreatures(player), 20L);
@@ -205,49 +206,49 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
             case 4: // Wolves gain +5% ms
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 4: Will add 5% movement speed to wolves when summoned");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 4: Wolves will gain +5% movement speed");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 4: Wolves will gain +5% movement speed");
                 }
                 break;
             case 5: // Boars gain +15% dmg
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 5: Will add 15% damage to boars when summoned");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 5: Boars will gain +15% damage");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 5: Boars will gain +15% damage");
                 }
                 break;
             case 6: // Bears gain +10% hp
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 6: Will add 10% health to bears when summoned");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 6: Bears will gain +10% health");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 6: Bears will gain +10% health");
                 }
                 break;
             case 7: // Wolves gain +5% as
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 7: Will add 5% attack speed to wolves when summoned");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 7: Wolves will gain +5% attack speed");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 7: Wolves will gain +5% attack speed");
                 }
                 break;
             case 8: // Boars gain +10% as
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 8: Will add 10% attack speed to boars when summoned");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 8: Boars will gain +10% attack speed");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 8: Boars will gain +10% attack speed");
                 }
                 break;
             case 9: // Summons gain +5% dmg
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 9: Will add 5% damage to all summons");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 9: All summons will gain +5% damage");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 9: All summons will gain +5% damage");
                 }
                 break;
             case 10: // Bears gain +50% def
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 10: Will add 50% defense to bears when summoned");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 10: Bears will gain +50% defense");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 10: Bears will gain +50% defense");
                 }
                 break;
             case 11: // Wolves gain 10% chance to crit
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 11: Will add 10% critical chance to wolves when summoned");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 11: Wolves will gain 10% crit chance");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 11: Wolves will gain 10% crit chance");
                 }
                 break;
             case 12: // Wolves gain +100hp
@@ -255,103 +256,103 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
                 // This will be handled separately in setWolfStats
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 12: Wolf HP bonus stored for application");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 12: Wolves gain +100 HP (flat bonus)");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 12: Wolves gain +100 HP (flat bonus)");
                 }
                 break;
             case 13: // Boars gain 15% chance to crit
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 13: Will add 15% critical chance to boars when summoned");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 13: Boars gain 15% crit chance");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 13: Boars gain 15% crit chance");
                 }
                 break;
             case 14: // Summons gain +10% dmg
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 14: Will add 10% damage to all summons");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 14: All summons gain +10% damage");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 14: All summons gain +10% damage");
                 }
                 break;
             case 15: // When Bears hp<50% u and ur summons gain +10% def
                 // This is handled dynamically during combat
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 15: Will handle bear guardian effect dynamically");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 15: Bear guardian effect enabled");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 15: Bear guardian effect enabled");
                 }
                 break;
             case 16: // Bears gain +200hp
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 16: Will add 200 HP to bears when summoned");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 16: Bears gain +200 HP");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 16: Bears gain +200 HP");
                 }
                 break;
             case 17: // Wolves heal's u for 5% of dmg dealt
                 // This is handled dynamically during combat
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 17: Will handle wolf healing dynamically");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 17: Wolf healing enabled");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 17: Wolf healing enabled");
                 }
                 break;
             case 18: // Summons gain +10% ms
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 18: Will add 10% movement speed to all summons");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 18: All summons gain +10% movement speed");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 18: All summons gain +10% movement speed");
                 }
                 break;
             case 19: // Boars after killing enemy gains +7% as for 3s
                 // This is handled dynamically during combat
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 19: Will handle boar frenzy dynamically");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 19: Boar frenzy enabled");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 19: Boar frenzy enabled");
                 }
                 break;
             case 20: // Bears heal for 10% hp each 10s
                 // This is handled via periodic task
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 20: Will handle bear regeneration via periodic task");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 20: Bear regeneration enabled");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 20: Bear regeneration enabled");
                 }
                 break;
             case 21: // Summons gain +30% hp
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 21: Will add 30% health to all summons");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 21: All summons gain +30% health");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 21: All summons gain +30% health");
                 }
                 break;
             case 22: // Wolves gain +10% hp
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 22: Will add 10% health to wolves when summoned");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 22: Wolves gain +10% health");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 22: Wolves gain +10% health");
                 }
                 break;
             case 23: // Boars gain 20% ms
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 23: Will add 20% movement speed to boars when summoned");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 23: Boars gain +20% movement speed");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 23: Boars gain +20% movement speed");
                 }
                 break;
             case 24: // Summons gain +25% def
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 24: Will add 25% defense to all summons");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 24: All summons gain +25% defense");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 24: All summons gain +25% defense");
                 }
                 break;
             case 25: // U summon 1 more wolf
                 // Handled by the summon wolf method
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 25: Will summon an additional wolf");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 25: Additional wolf enabled");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 25: Additional wolf enabled");
                 }
                 break;
             case 26: // Boars gain +15% dmg and +15% as
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 26: Will add 15% damage and 15% attack speed to boars when summoned");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 26: Boars gain +15% damage and +15% attack speed");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 26: Boars gain +15% damage and +15% attack speed");
                 }
                 break;
             case 27: // Heals ur summons for 5% of yours dmg dealt
                 // This is handled dynamically during combat
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("BEASTMASTER SKILL 27: Will handle summon healing dynamically");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 27: Summon healing enabled");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] BEASTMASTER SKILL 27: Summon healing enabled");
                 }
                 break;
             default:
@@ -425,7 +426,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
         
         if (removedCount > 0 && debuggingFlag == 1) {
             plugin.getLogger().info("Cleaned up " + removedCount + " untracked summons for " + player.getName());
-            player.sendMessage(ChatColor.YELLOW + "Cleaned up " + removedCount + " duplicate summons.");
+            ChatNotificationUtils.send(player, ChatColor.YELLOW + "Cleaned up " + removedCount + " duplicate summons.");
         }
     }
 
@@ -475,26 +476,26 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
 
         // Check if player has the skill
         if (!isPurchased(playerId, WOLF_SUMMON_ID)) {
-            player.sendMessage(ChatColor.RED + "You haven't learned to summon wolves yet!");
+            ChatNotificationUtils.send(player, ChatColor.RED + "You haven't learned to summon wolves yet!");
             return;
         }
 
         // Check summon type limit
         if (!canAddSummonType(playerId, WOLF_SUMMON_ID)) {
-            player.sendMessage(ChatColor.RED + "You can only have 2 types of summons at once!");
+            ChatNotificationUtils.send(player, ChatColor.RED + "You can only have 2 types of summons at once!");
             return;
         }
 
         // Check if wolf is already summoned
         if (hasActiveSummon(playerId, playerWolf)) {
-            player.sendMessage(ChatColor.YELLOW + "You already have a wolf summoned!");
+            ChatNotificationUtils.send(player, ChatColor.YELLOW + "You already have a wolf summoned!");
             return;
         }
 
         // Check cooldown
         if (isOnCooldown(playerId, wolfRespawnCooldowns, WOLF_SUMMON_COOLDOWN)) {
             long timeLeft = (wolfRespawnCooldowns.get(playerId) + WOLF_SUMMON_COOLDOWN - System.currentTimeMillis()) / 1000;
-            player.sendMessage(ChatColor.RED + "Wolf summon on cooldown (" + timeLeft + "s)");
+            ChatNotificationUtils.send(player, ChatColor.RED + "Wolf summon on cooldown (" + timeLeft + "s)");
             return;
         }
 
@@ -522,7 +523,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
         int wolfCount = maxWolves - currentWolfCount;
 
         if (wolfCount <= 0) {
-            player.sendMessage(ChatColor.YELLOW + "You already have all your wolves summoned!");
+            ChatNotificationUtils.send(player, ChatColor.YELLOW + "You already have all your wolves summoned!");
             return;
         }
 
@@ -568,7 +569,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
         } catch (Exception e) {
             plugin.getLogger().severe("Error spawning wolf: " + e.getMessage());
             e.printStackTrace();
-            player.sendMessage(ChatColor.RED + "Error summoning wolf: " + e.getMessage());
+            ChatNotificationUtils.send(player, ChatColor.RED + "Error summoning wolf: " + e.getMessage());
         } finally {
             // Clear summon in progress flag
             summonInProgress.put(playerId, false);
@@ -576,7 +577,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
 
         if (debuggingFlag == 1) {
             plugin.getLogger().info(player.getName() + " summoned " + wolfCount + " wolves");
-            player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] Summoned " + wolfCount + " wolves");
+            ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] Summoned " + wolfCount + " wolves");
         }
     }
 
@@ -610,26 +611,26 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
 
         // Check if player has the skill
         if (!isPurchased(playerId, BOAR_SUMMON_ID)) {
-            player.sendMessage(ChatColor.RED + "You haven't learned to summon boars yet!");
+            ChatNotificationUtils.send(player, ChatColor.RED + "You haven't learned to summon boars yet!");
             return;
         }
 
         // Check summon type limit
         if (!canAddSummonType(playerId, BOAR_SUMMON_ID)) {
-            player.sendMessage(ChatColor.RED + "You can only have 2 types of summons at once!");
+            ChatNotificationUtils.send(player, ChatColor.RED + "You can only have 2 types of summons at once!");
             return;
         }
 
         // Check if boar is already summoned
         if (hasActiveSummon(playerId, playerBoar)) {
-            player.sendMessage(ChatColor.YELLOW + "You already have a boar summoned!");
+            ChatNotificationUtils.send(player, ChatColor.YELLOW + "You already have a boar summoned!");
             return;
         }
 
         // Check cooldown
         if (isOnCooldown(playerId, boarRespawnCooldowns, BOAR_SUMMON_COOLDOWN)) {
             long timeLeft = (boarRespawnCooldowns.get(playerId) + BOAR_SUMMON_COOLDOWN - System.currentTimeMillis()) / 1000;
-            player.sendMessage(ChatColor.RED + "Boar summon on cooldown (" + timeLeft + "s)");
+            ChatNotificationUtils.send(player, ChatColor.RED + "Boar summon on cooldown (" + timeLeft + "s)");
             return;
         }
 
@@ -711,7 +712,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
         } catch (Exception e) {
             plugin.getLogger().severe("Error spawning boar: " + e.getMessage());
             e.printStackTrace();
-            player.sendMessage(ChatColor.RED + "Error summoning boar: " + e.getMessage());
+            ChatNotificationUtils.send(player, ChatColor.RED + "Error summoning boar: " + e.getMessage());
         } finally {
             // Clear summon in progress flag
             summonInProgress.put(playerId, false);
@@ -748,26 +749,26 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
 
         // Check if player has the skill
         if (!isPurchased(playerId, BEAR_SUMMON_ID)) {
-            player.sendMessage(ChatColor.RED + "You haven't learned to summon bears yet!");
+            ChatNotificationUtils.send(player, ChatColor.RED + "You haven't learned to summon bears yet!");
             return;
         }
 
         // Check summon type limit
         if (!canAddSummonType(playerId, BEAR_SUMMON_ID)) {
-            player.sendMessage(ChatColor.RED + "You can only have 2 types of summons at once!");
+            ChatNotificationUtils.send(player, ChatColor.RED + "You can only have 2 types of summons at once!");
             return;
         }
 
         // Check if bear is already summoned
         if (hasActiveSummon(playerId, playerBear)) {
-            player.sendMessage(ChatColor.YELLOW + "You already have a bear summoned!");
+            ChatNotificationUtils.send(player, ChatColor.YELLOW + "You already have a bear summoned!");
             return;
         }
 
         // Check cooldown
         if (isOnCooldown(playerId, bearRespawnCooldowns, BEAR_SUMMON_COOLDOWN)) {
             long timeLeft = (bearRespawnCooldowns.get(playerId) + BEAR_SUMMON_COOLDOWN - System.currentTimeMillis()) / 1000;
-            player.sendMessage(ChatColor.RED + "Bear summon on cooldown (" + timeLeft + "s)");
+            ChatNotificationUtils.send(player, ChatColor.RED + "Bear summon on cooldown (" + timeLeft + "s)");
             return;
         }
 
@@ -849,7 +850,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
         } catch (Exception e) {
             plugin.getLogger().severe("Error spawning bear: " + e.getMessage());
             e.printStackTrace();
-            player.sendMessage(ChatColor.RED + "Error summoning bear: " + e.getMessage());
+            ChatNotificationUtils.send(player, ChatColor.RED + "Error summoning bear: " + e.getMessage());
         } finally {
             // Clear summon in progress flag
             summonInProgress.put(playerId, false);
@@ -905,7 +906,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
                 removeSummonType(player, WOLF_SUMMON_ID);
             }
             
-            player.sendMessage(ChatColor.RED + "Some of your summons have been removed because you exceeded the limit.");
+            ChatNotificationUtils.send(player, ChatColor.RED + "Some of your summons have been removed because you exceeded the limit.");
         }
         
         // Update all summon name tags to ensure they're correct
@@ -1088,9 +1089,9 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
             
             // Notify player when guardian activates/deactivates
             if (isActive && !wasActive) {
-                player.sendMessage(ChatColor.GOLD + "Bear Guardian activated! +10% defense for you and summons!");
+                ChatNotificationUtils.send(player, ChatColor.GOLD + "Bear Guardian activated! +10% defense for you and summons!");
             } else if (!isActive && wasActive) {
-                player.sendMessage(ChatColor.YELLOW + "Bear Guardian deactivated.");
+                ChatNotificationUtils.send(player, ChatColor.YELLOW + "Bear Guardian deactivated.");
             }
         }
     }
@@ -1767,6 +1768,10 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
      */
     @Override
     public void handleEntityDamageByEntity(EntityDamageByEntityEvent event, Player player, SkillEffectsHandler.PlayerSkillStats stats) {
+        if (event.isCancelled()) {
+            return;
+        }
+
         // Get the damager and the entity being damaged
         Entity damager = event.getDamager();
         Entity entity = event.getEntity();
@@ -1803,7 +1808,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
                 }
                 
                 if (debuggingFlag == 1) {
-                    player.sendMessage(ChatColor.RED + "Your " + critSource + " landed a critical hit!");
+                    ChatNotificationUtils.send(player, ChatColor.RED + "Your " + critSource + " landed a critical hit!");
                 }
             }
             
@@ -1819,7 +1824,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
                 player.setHealth(newHealth);
                 
                 if (debuggingFlag == 1 && healAmount > 0) {
-                    player.sendMessage(ChatColor.GREEN + "Healed for " + String.format("%.1f", healAmount) + " HP from wolf damage!");
+                    ChatNotificationUtils.send(player, ChatColor.GREEN + "Healed for " + String.format("%.1f", healAmount) + " HP from wolf damage!");
                 }
             }
 
@@ -1874,7 +1879,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
             event.setDamage(newDamage);
             
             if (debuggingFlag == 1) {
-                player.sendMessage(ChatColor.GREEN + "Your bear guardian reduced damage by 20%!");
+                ChatNotificationUtils.send(player, ChatColor.GREEN + "Your bear guardian reduced damage by 20%!");
             }
         }
     }
@@ -1899,7 +1904,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
                         .put(killer.getUniqueId(), System.currentTimeMillis() + 3000); // 3 seconds
                     
                     if (debuggingFlag == 1) {
-                        p.sendMessage(ChatColor.RED + "Your boar enters a frenzy! +7% attack speed for 3s!");
+                        ChatNotificationUtils.send(p, ChatColor.RED + "Your boar enters a frenzy! +7% attack speed for 3s!");
                     }
                 }
             }
@@ -1910,7 +1915,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
             // Handle wolf death
             if (debuggingFlag == 1) {
                 plugin.getLogger().info("Player " + player.getName() + "'s wolf died");
-                player.sendMessage(ChatColor.RED + "Your wolf has died!");
+                ChatNotificationUtils.send(player, ChatColor.RED + "Your wolf has died!");
             }
             
             // Remove the wolf from tracking
@@ -1930,7 +1935,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
                             if (!hasActiveSummon(playerId, playerWolf)) {
                                 summonWolves(p);
                                 if (debuggingFlag == 1) {
-                                    p.sendMessage(ChatColor.GREEN + "Your wolf has been automatically resummoned!");
+                                    ChatNotificationUtils.send(p, ChatColor.GREEN + "Your wolf has been automatically resummoned!");
                                 }
                             }
                         } else {
@@ -1957,7 +1962,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
             // Handle boar death
             if (debuggingFlag == 1) {
                 plugin.getLogger().info("Player " + player.getName() + "'s boar died");
-                player.sendMessage(ChatColor.RED + "Your boar has died!");
+                ChatNotificationUtils.send(player, ChatColor.RED + "Your boar has died!");
             }
             
             // Remove the boar from tracking
@@ -1977,7 +1982,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
                             if (!hasActiveSummon(playerId, playerBoar)) {
                                 summonBoars(p);
                                 if (debuggingFlag == 1) {
-                                    p.sendMessage(ChatColor.GREEN + "Your boar has been automatically resummoned!");
+                                    ChatNotificationUtils.send(p, ChatColor.GREEN + "Your boar has been automatically resummoned!");
                                 }
                             }
                         } else {
@@ -1995,7 +2000,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
             // Handle bear death
             if (debuggingFlag == 1) {
                 plugin.getLogger().info("Player " + player.getName() + "'s bear died");
-                player.sendMessage(ChatColor.RED + "Your bear has died!");
+                ChatNotificationUtils.send(player, ChatColor.RED + "Your bear has died!");
             }
             
             // Remove the bear from tracking
@@ -2018,7 +2023,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
                             if (!hasActiveSummon(playerId, playerBear)) {
                                 summonBears(p);
                                 if (debuggingFlag == 1) {
-                                    p.sendMessage(ChatColor.GREEN + "Your bear has been automatically resummoned!");
+                                    ChatNotificationUtils.send(p, ChatColor.GREEN + "Your bear has been automatically resummoned!");
                                 }
                             }
                         } else {
@@ -2060,7 +2065,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
         
         // Get player's ascendancy
         String ascendancy = plugin.getClassManager().getPlayerAscendancy(playerId);
-        if (!"Beastmaster".equals(ascendancy)) {
+        if (!"Beastmaster".equalsIgnoreCase(ascendancy)) {
             return;
         }
         
@@ -2091,7 +2096,7 @@ public class BeastmasterSkillEffectsHandler extends BaseSkillEffectsHandler impl
         
         // Check if player is a Beastmaster
         String ascendancy = plugin.getClassManager().getPlayerAscendancy(playerId);
-        if (!"Beastmaster".equals(ascendancy)) {
+        if (!"Beastmaster".equalsIgnoreCase(ascendancy)) {
             return;
         }
         

--- a/src/main/java/com/maks/myexperienceplugin/Class/skills/effects/ascendancy/EarthwardenSkillEffectsHandler.java
+++ b/src/main/java/com/maks/myexperienceplugin/Class/skills/effects/ascendancy/EarthwardenSkillEffectsHandler.java
@@ -5,6 +5,7 @@ import com.maks.myexperienceplugin.Class.skills.effects.BaseSkillEffectsHandler;
 import com.maks.myexperienceplugin.MyExperiencePlugin;
 import com.maks.myexperienceplugin.utils.ActionBarUtils;
 import com.maks.myexperienceplugin.utils.DebugUtils;
+import com.maks.myexperienceplugin.utils.ChatNotificationUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -202,7 +203,7 @@ public class EarthwardenSkillEffectsHandler extends BaseSkillEffectsHandler impl
                 // This is handled dynamically in the periodic effects
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("EARTHWARDEN SKILL 1: Will add 3% defense in grassy areas");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] EARTHWARDEN SKILL 1: +3% defense in grassy areas enabled");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] EARTHWARDEN SKILL 1: +3% defense in grassy areas enabled");
                 }
                 break;
 
@@ -210,7 +211,7 @@ public class EarthwardenSkillEffectsHandler extends BaseSkillEffectsHandler impl
                 // This is handled in the EntityDeathEvent
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("EARTHWARDEN SKILL 2: Will heal 1 hp after killing an enemy");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] EARTHWARDEN SKILL 2: Heal 1 HP after killing enemy enabled");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] EARTHWARDEN SKILL 2: Heal 1 HP after killing enemy enabled");
                 }
                 break;
 
@@ -218,7 +219,7 @@ public class EarthwardenSkillEffectsHandler extends BaseSkillEffectsHandler impl
                 // This is handled in the EntityDamageEvent
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("EARTHWARDEN SKILL 3: Will add 5% resistance to environmental damage");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] EARTHWARDEN SKILL 3: +5% resistance to environmental damage enabled");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] EARTHWARDEN SKILL 3: +5% resistance to environmental damage enabled");
                 }
                 break;
 
@@ -229,7 +230,7 @@ public class EarthwardenSkillEffectsHandler extends BaseSkillEffectsHandler impl
                 stats.addMaxHealth(hpBonus);
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("EARTHWARDEN SKILL 4: Added " + hpBonus + " HP (skill level " + purchaseCount + "/3)");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] EARTHWARDEN SKILL 4: +" + hpBonus + " HP (level " + purchaseCount + "/3)");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] EARTHWARDEN SKILL 4: +" + hpBonus + " HP (level " + purchaseCount + "/3)");
                 }
                 break;
 
@@ -237,7 +238,7 @@ public class EarthwardenSkillEffectsHandler extends BaseSkillEffectsHandler impl
                 // This is handled dynamically in the periodic effects
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("EARTHWARDEN SKILL 5: Will add 10% defense after standing still for 3 seconds");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] EARTHWARDEN SKILL 5: +10% defense after standing still for 3s enabled");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] EARTHWARDEN SKILL 5: +10% defense after standing still for 3s enabled");
                 }
                 break;
 
@@ -245,7 +246,7 @@ public class EarthwardenSkillEffectsHandler extends BaseSkillEffectsHandler impl
                 // This is handled dynamically during gameplay
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("EARTHWARDEN SKILL 6: Will add 5% luck when below 50% hp");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] EARTHWARDEN SKILL 6: +5% luck when HP < 50% enabled");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] EARTHWARDEN SKILL 6: +5% luck when HP < 50% enabled");
                 }
                 break;
 
@@ -253,7 +254,7 @@ public class EarthwardenSkillEffectsHandler extends BaseSkillEffectsHandler impl
                 // This is handled in the EntityDamageEvent
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("EARTHWARDEN SKILL 7: Will add 5% defense for 3 seconds when hp<50%");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] EARTHWARDEN SKILL 7: +5% defense for 3s when HP < 50% enabled");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] EARTHWARDEN SKILL 7: +5% defense for 3s when HP < 50% enabled");
                 }
                 break;
 
@@ -261,7 +262,7 @@ public class EarthwardenSkillEffectsHandler extends BaseSkillEffectsHandler impl
                 // This is handled in the EntityDamageByEntityEvent
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("EARTHWARDEN SKILL 8: Will root enemies every 10 seconds");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] EARTHWARDEN SKILL 8: Root enemies every 10s enabled");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] EARTHWARDEN SKILL 8: Root enemies every 10s enabled");
                 }
                 break;
 
@@ -527,7 +528,7 @@ public class EarthwardenSkillEffectsHandler extends BaseSkillEffectsHandler impl
                 secondChanceCooldowns.put(playerId, System.currentTimeMillis());
                 immunityEndTimes.put(playerId, System.currentTimeMillis() + 2000); // 2 seconds
 
-                player.sendMessage(ChatColor.GOLD + "Your Second Chance has saved you from death!");
+                ChatNotificationUtils.send(player, ChatColor.GOLD + "Your Second Chance has saved you from death!");
                 ActionBarUtils.sendActionBar(player, ChatColor.GOLD + "Second Chance activated!");
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("EARTHWARDEN: Applied Second Chance for " + player.getName());
@@ -676,7 +677,7 @@ public class EarthwardenSkillEffectsHandler extends BaseSkillEffectsHandler impl
     /**
      * Handle entity damage by entity events
      */
-    @EventHandler(priority = EventPriority.HIGH)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
         if (event.isCancelled()) {
             return;

--- a/src/main/java/com/maks/myexperienceplugin/Class/skills/effects/ascendancy/ElementalistSkillEffectsHandler.java
+++ b/src/main/java/com/maks/myexperienceplugin/Class/skills/effects/ascendancy/ElementalistSkillEffectsHandler.java
@@ -4,6 +4,7 @@ import com.maks.myexperienceplugin.Class.skills.SkillEffectsHandler;
 import com.maks.myexperienceplugin.Class.skills.effects.BaseSkillEffectsHandler;
 import com.maks.myexperienceplugin.MyExperiencePlugin;
 import com.maks.myexperienceplugin.utils.ActionBarUtils;
+import com.maks.myexperienceplugin.utils.ChatNotificationUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Particle;
@@ -61,42 +62,42 @@ public class ElementalistSkillEffectsHandler extends BaseSkillEffectsHandler imp
                 stats.addSpellDamageBonus(5 * purchaseCount);
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("ELEMENTALIST SKILL 1: Added " + (5 * purchaseCount) + " spell damage bonus");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] ELEMENTALIST SKILL 1: +" + (5 * purchaseCount) + " spell damage (Fire Mastery)");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] ELEMENTALIST SKILL 1: +" + (5 * purchaseCount) + " spell damage (Fire Mastery)");
                 }
                 break;
             case 2: // Ice Mastery
                 stats.addSpellDamageBonus(5 * purchaseCount);
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("ELEMENTALIST SKILL 2: Added " + (5 * purchaseCount) + " spell damage bonus");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] ELEMENTALIST SKILL 2: +" + (5 * purchaseCount) + " spell damage (Ice Mastery)");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] ELEMENTALIST SKILL 2: +" + (5 * purchaseCount) + " spell damage (Ice Mastery)");
                 }
                 break;
             case 3: // Lightning Mastery
                 stats.addSpellDamageBonus(5 * purchaseCount);
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("ELEMENTALIST SKILL 3: Added " + (5 * purchaseCount) + " spell damage bonus");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] ELEMENTALIST SKILL 3: +" + (5 * purchaseCount) + " spell damage (Lightning Mastery)");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] ELEMENTALIST SKILL 3: +" + (5 * purchaseCount) + " spell damage (Lightning Mastery)");
                 }
                 break;
             case 4: // Flame Burst
                 // Effect applied in damage handler
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("ELEMENTALIST SKILL 4: Will apply Flame Burst dynamically");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] ELEMENTALIST SKILL 4: Flame Burst enabled");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] ELEMENTALIST SKILL 4: Flame Burst enabled");
                 }
                 break;
             case 5: // Frost Nova
                 // Effect applied in damage handler
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("ELEMENTALIST SKILL 5: Will apply Frost Nova dynamically");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] ELEMENTALIST SKILL 5: Frost Nova enabled");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] ELEMENTALIST SKILL 5: Frost Nova enabled");
                 }
                 break;
             case 6: // Chain Lightning
                 // Effect applied in damage handler
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("ELEMENTALIST SKILL 6: Will apply Chain Lightning dynamically");
-                    player.sendMessage(ChatColor.DARK_GRAY + "[DEBUG] ELEMENTALIST SKILL 6: Chain Lightning enabled");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "[DEBUG] ELEMENTALIST SKILL 6: Chain Lightning enabled");
                 }
                 break;
             case 7: // Heat Wave
@@ -864,7 +865,7 @@ public class ElementalistSkillEffectsHandler extends BaseSkillEffectsHandler imp
 
                 // Notify player
                 ActionBarUtils.sendActionBar(player, ChatColor.GOLD + "Elemental Mastery activated!");
-                player.sendMessage(ChatColor.GOLD + "You have combined the power of all three elements!");
+                ChatNotificationUtils.send(player, ChatColor.GOLD + "You have combined the power of all three elements!");
             }
         }
     }

--- a/src/main/java/com/maks/myexperienceplugin/Class/skills/effects/ascendancy/FlameWardenSkillEffectsHandler.java
+++ b/src/main/java/com/maks/myexperienceplugin/Class/skills/effects/ascendancy/FlameWardenSkillEffectsHandler.java
@@ -5,6 +5,7 @@ import com.maks.myexperienceplugin.Class.skills.effects.BaseSkillEffectsHandler;
 import com.maks.myexperienceplugin.MyExperiencePlugin;
 import com.maks.myexperienceplugin.utils.ActionBarUtils;
 import com.maks.myexperienceplugin.utils.DebugUtils;
+import com.maks.myexperienceplugin.utils.ChatNotificationUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -132,7 +133,7 @@ public class FlameWardenSkillEffectsHandler extends BaseSkillEffectsHandler {
             case 3: // Gain fire resistance potion effect infinity
                 // Apply fire resistance potion effect (infinite duration, hidden)
                 player.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, Integer.MAX_VALUE, 0, false, false));
-                player.sendMessage(ChatColor.GOLD + "You feel protected from fire! (Fire Resistance effect applied)");
+                ChatNotificationUtils.send(player, ChatColor.GOLD + "You feel protected from fire! (Fire Resistance effect applied)");
                 
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("FLAMEWARDEN SKILL 3: Applied hidden fire resistance effect to " + player.getName());
@@ -452,7 +453,7 @@ public class FlameWardenSkillEffectsHandler extends BaseSkillEffectsHandler {
             double damageBonus = Math.min(BURNING_AURA_MAX, burningEnemiesCount * BURNING_AURA_BONUS);
 
             // Send chat message with burning enemies count
-            player.sendMessage(ChatColor.GOLD + "[Burning Aura] " + burningEnemiesCount + " burning enemies nearby");
+            ChatNotificationUtils.send(player, ChatColor.GOLD + "[Burning Aura] " + burningEnemiesCount + " burning enemies nearby");
 
             if (damageBonus > 0) {
                 double originalDamage = event.getDamage();
@@ -471,7 +472,7 @@ public class FlameWardenSkillEffectsHandler extends BaseSkillEffectsHandler {
             int burningEnemiesCount = countBurningEnemiesNearby(player, 10);
             
             // Send chat message with burning enemies count
-            player.sendMessage(ChatColor.GOLD + "[Burning Presence] " + burningEnemiesCount + " burning enemies nearby" + 
+            ChatNotificationUtils.send(player, ChatColor.GOLD + "[Burning Presence] " + burningEnemiesCount + " burning enemies nearby" +
                     (burningEnemiesCount >= 3 ? " - ACTIVE!" : " - Need 3+ for activation"));
 
             if (burningEnemiesCount >= 3) {
@@ -1174,7 +1175,7 @@ public class FlameWardenSkillEffectsHandler extends BaseSkillEffectsHandler {
                 // Show notification to player when they respawn
                 if (player.isOnline()) {
                     ActionBarUtils.sendActionBar(player, ChatColor.GOLD + "☀ Phoenix Rebirth Activated! ☀");
-                    player.sendMessage(ChatColor.GOLD + "You exploded in a fiery rebirth! (5 minute cooldown)");
+                    ChatNotificationUtils.send(player, ChatColor.GOLD + "You exploded in a fiery rebirth! (5 minute cooldown)");
                 }
 
                 if (debuggingFlag == 1) {

--- a/src/main/java/com/maks/myexperienceplugin/Class/skills/effects/ascendancy/ShadowstalkerSkillEffectsHandler.java
+++ b/src/main/java/com/maks/myexperienceplugin/Class/skills/effects/ascendancy/ShadowstalkerSkillEffectsHandler.java
@@ -6,6 +6,7 @@ import com.maks.myexperienceplugin.Class.skills.effects.BaseSkillEffectsHandler;
 import com.maks.myexperienceplugin.MyExperiencePlugin;
 import com.maks.myexperienceplugin.utils.ActionBarUtils;
 import com.maks.myexperienceplugin.utils.DebugUtils;
+import com.maks.myexperienceplugin.utils.ChatNotificationUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -157,7 +158,7 @@ public class ShadowstalkerSkillEffectsHandler extends BaseSkillEffectsHandler {
             
             if (success) {
                 event.setCancelled(true);
-                player.sendMessage(ChatColor.GRAY + "Evaded!");
+                ChatNotificationUtils.send(player, ChatColor.GRAY + "Evaded!");
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("→ Evaded while sneaking!");
                 }
@@ -182,7 +183,7 @@ public class ShadowstalkerSkillEffectsHandler extends BaseSkillEffectsHandler {
             
             if (success) {
                 event.setCancelled(true);
-                player.sendMessage(ChatColor.DARK_GRAY + "Shadow evade!");
+                ChatNotificationUtils.send(player, ChatColor.DARK_GRAY + "Shadow evade!");
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("→ Shadow evaded in darkness!");
                 }
@@ -206,7 +207,7 @@ public class ShadowstalkerSkillEffectsHandler extends BaseSkillEffectsHandler {
             
             if (success) {
                 event.setCancelled(true);
-                player.sendMessage(ChatColor.RED + "Desperate evade!");
+                ChatNotificationUtils.send(player, ChatColor.RED + "Desperate evade!");
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("→ Desperate evaded at low health!");
                 }
@@ -284,7 +285,7 @@ public class ShadowstalkerSkillEffectsHandler extends BaseSkillEffectsHandler {
 
         if (isPurchased(playerId, ID_OFFSET + 23) && attackCount % 3 == 0) {
             isCritical = true;
-            player.sendMessage(ChatColor.GOLD + "Precision Strike!");
+            ChatNotificationUtils.send(player, ChatColor.GOLD + "Precision Strike!");
             if (debuggingFlag == 1) {
                 plugin.getLogger().info("SHADOWSTALKER: " + player.getName() + " triggered Precision Strike (skill 23) on " + target.getName());
             }
@@ -357,7 +358,7 @@ public class ShadowstalkerSkillEffectsHandler extends BaseSkillEffectsHandler {
         if (isPurchased(playerId, ID_OFFSET + 19)) {
             if (previousAttackTime == null || (System.currentTimeMillis() - previousAttackTime) > 3000) {
                 finalDamage *= 1.35;
-                player.sendMessage(ChatColor.DARK_GREEN + "Ambush!");
+                ChatNotificationUtils.send(player, ChatColor.DARK_GREEN + "Ambush!");
                 
                 if (debuggingFlag == 1) {
                     plugin.getLogger().info("SHADOWSTALKER: " + player.getName() + " triggered Ambush (+35% damage) on " + target.getName());
@@ -414,7 +415,7 @@ public class ShadowstalkerSkillEffectsHandler extends BaseSkillEffectsHandler {
                 double devastatingChance = 10 * purchaseCount;
                 if (rollChance(devastatingChance, player, "Devastating Critical")) {
                     finalDamage *= 1.5;
-                    player.sendMessage(ChatColor.DARK_RED + "DEVASTATING CRITICAL!");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_RED + "DEVASTATING CRITICAL!");
                     
                     if (debuggingFlag == 1) {
                         plugin.getLogger().info("SHADOWSTALKER: " + player.getName() + " triggered Devastating Critical (" + String.format("%.1f", devastatingChance) + "% chance) on " + target.getName());
@@ -444,7 +445,7 @@ public class ShadowstalkerSkillEffectsHandler extends BaseSkillEffectsHandler {
                 double amplifyChance = 25 * purchaseCount;
                 if (rollChance(amplifyChance, player, "Poison Amplification")) {
                     amplifyPoison(targetId, playerId);
-                    player.sendMessage(ChatColor.DARK_GREEN + "Poison Amplified!");
+                    ChatNotificationUtils.send(player, ChatColor.DARK_GREEN + "Poison Amplified!");
                     
                     if (debuggingFlag == 1) {
                         plugin.getLogger().info("SHADOWSTALKER: " + player.getName() + " amplified poison on " + target.getName() + " (" + String.format("%.1f", amplifyChance) + "% chance)");
@@ -497,7 +498,7 @@ public class ShadowstalkerSkillEffectsHandler extends BaseSkillEffectsHandler {
         // Skill 25: After attacking from sneaking, gain +40% attack speed for 3 seconds
         if (isPurchased(playerId, ID_OFFSET + 25) && player.isSneaking()) {
             ambushSpeedExpiry.put(playerId, System.currentTimeMillis() + 3000);
-            player.sendMessage(ChatColor.YELLOW + "Ambush Speed activated!");
+            ChatNotificationUtils.send(player, ChatColor.YELLOW + "Ambush Speed activated!");
         }
 
         // Ustaw finalne obrażenia
@@ -516,7 +517,7 @@ public class ShadowstalkerSkillEffectsHandler extends BaseSkillEffectsHandler {
         // Skill 10: After killing an enemy, gain +10% movement speed for 5 seconds
         if (isPurchased(playerId, ID_OFFSET + 10)) {
             assassinHasteExpiry.put(playerId, System.currentTimeMillis() + 5000);
-            player.sendMessage(ChatColor.GREEN + "Assassin's Haste activated!");
+            ChatNotificationUtils.send(player, ChatColor.GREEN + "Assassin's Haste activated!");
             
             if (debuggingFlag == 1) {
                 plugin.getLogger().info("SHADOWSTALKER: " + player.getName() + " activated Assassin's Haste (+10% movement speed for 5s)");

--- a/src/main/java/com/maks/myexperienceplugin/Class/skills/gui/AscendancySkillTreeGUI.java
+++ b/src/main/java/com/maks/myexperienceplugin/Class/skills/gui/AscendancySkillTreeGUI.java
@@ -540,7 +540,7 @@ public class AscendancySkillTreeGUI {
         List<String> lore = new ArrayList<>();
 
         // Choose appropriate material and lore based on ascendancy and branch
-        if ("Beastmaster".equals(ascendancy)) {
+        if ("Beastmaster".equalsIgnoreCase(ascendancy)) {
             if ("Wolf Path".equals(branchName)) {
                 material = Material.BONE;
                 lore.add(ChatColor.GRAY + "Focus on wolves and their abilities");

--- a/src/main/java/com/maks/myexperienceplugin/MyExperiencePlugin.java
+++ b/src/main/java/com/maks/myexperienceplugin/MyExperiencePlugin.java
@@ -825,7 +825,7 @@ public class MyExperiencePlugin extends JavaPlugin implements Listener {
 
         // Remove all summons for Beastmaster players
         String ascendancy = classManager.getPlayerAscendancy(uuid);
-        if ("Beastmaster".equals(ascendancy) && ascendancySkillEffectIntegrator != null) {
+        if ("Beastmaster".equalsIgnoreCase(ascendancy) && ascendancySkillEffectIntegrator != null) {
             com.maks.myexperienceplugin.Class.skills.effects.ascendancy.BeastmasterSkillEffectsHandler handler = 
                 (com.maks.myexperienceplugin.Class.skills.effects.ascendancy.BeastmasterSkillEffectsHandler) 
                 ascendancySkillEffectIntegrator.getHandler("Beastmaster");
@@ -930,7 +930,7 @@ public class MyExperiencePlugin extends JavaPlugin implements Listener {
             // Respawn summons for Beastmaster players
             UUID uuid = player.getUniqueId();
             String ascendancy = classManager.getPlayerAscendancy(uuid);
-            if ("Beastmaster".equals(ascendancy) && ascendancySkillEffectIntegrator != null) {
+            if ("Beastmaster".equalsIgnoreCase(ascendancy) && ascendancySkillEffectIntegrator != null) {
                 com.maks.myexperienceplugin.Class.skills.effects.ascendancy.BeastmasterSkillEffectsHandler handler = 
                     (com.maks.myexperienceplugin.Class.skills.effects.ascendancy.BeastmasterSkillEffectsHandler) 
                     ascendancySkillEffectIntegrator.getHandler("Beastmaster");

--- a/src/main/java/com/maks/myexperienceplugin/listener/LifestealListener.java
+++ b/src/main/java/com/maks/myexperienceplugin/listener/LifestealListener.java
@@ -3,13 +3,15 @@ package com.maks.myexperienceplugin.listener;
 import com.maks.myexperienceplugin.alchemy.LifestealManager;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.attribute.Attribute;
 
 public class LifestealListener implements Listener {
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
+        if (event.isCancelled()) return;
         if (!(event.getDamager() instanceof Player)) return;
         Player player = (Player) event.getDamager();
         double lifesteal = LifestealManager.getInstance().getLifesteal(player);

--- a/src/main/java/com/maks/myexperienceplugin/utils/ChatNotificationUtils.java
+++ b/src/main/java/com/maks/myexperienceplugin/utils/ChatNotificationUtils.java
@@ -1,0 +1,20 @@
+package com.maks.myexperienceplugin.utils;
+
+import org.bukkit.entity.Player;
+
+/** Utility for skill-related chat messages. */
+public class ChatNotificationUtils {
+    /** Toggle for chat notifications. Disabled by default to prevent spam. */
+    public static boolean ENABLED = false;
+
+    /**
+     * Sends a chat message if notifications are enabled.
+     * @param player target player
+     * @param message message text
+     */
+    public static void send(Player player, String message) {
+        if (ENABLED) {
+            player.sendMessage(message);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- use `ChatNotificationUtils` across more ascendancy handlers
- ensure Beastmaster messages don't spam chat
- case-insensitive Beastmaster detection and cooldown checks remain

## Testing
- `mvn -q -DskipTests package` *(fails: could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6884a29d4b7c832aa3a1ea6ff96c87d8