### PR TITLE
Integrate EssentialsX for level display

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,10 @@
             <id>md_5-public</id>
             <url>https://repo.md-5.net/content/groups/public/</url>
         </repository>
+        <repository>
+            <id>essentials-repo</id>
+            <url>https://repo.essentialsx.net/releases/</url>
+        </repository>
     </repositories>
 
   <dependencies>
@@ -106,6 +110,12 @@
           <groupId>net.luckperms</groupId>
           <artifactId>api</artifactId>
           <version>5.4</version>
+          <scope>provided</scope>
+      </dependency>
+      <dependency>
+          <groupId>net.essentialsx</groupId>
+          <artifactId>EssentialsX</artifactId>
+          <version>2.20.0</version>
           <scope>provided</scope>
       </dependency>
   </dependencies>

--- a/src/main/java/com/maks/myexperienceplugin/exp/PlayerLevelDisplayHandler.java
+++ b/src/main/java/com/maks/myexperienceplugin/exp/PlayerLevelDisplayHandler.java
@@ -1,21 +1,25 @@
 package com.maks.myexperienceplugin.exp;
 
 import com.maks.myexperienceplugin.MyExperiencePlugin;
+import com.earth2me.essentials.Essentials;
+import com.earth2me.essentials.User;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
 
 public class PlayerLevelDisplayHandler implements Listener {
 
     private final MyExperiencePlugin plugin;
+    private final Essentials essentials;
 
     public PlayerLevelDisplayHandler(MyExperiencePlugin plugin) {
         this.plugin = plugin;
-        setupScoreboardTeam();
+        this.essentials = (Essentials) Bukkit.getPluginManager().getPlugin("Essentials");
     }
 
     @EventHandler
@@ -25,6 +29,11 @@ public class PlayerLevelDisplayHandler implements Listener {
 
         // Aktualizacja wszystkich graczy w tabie po dołączeniu nowego gracza
         Bukkit.getScheduler().runTaskLater(plugin, this::updateAllPlayerTabs, 20L);
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        removePlayerTeam(event.getPlayer());
     }
 
     public void updatePlayerTab(Player player) {
@@ -37,20 +46,30 @@ public class PlayerLevelDisplayHandler implements Listener {
             return;
         }
 
-        // Pobierz team "level_display"
-        Team team = scoreboard.getTeam("level_display");
+        String teamName = "level_" + player.getName();
+        Team team = scoreboard.getTeam(teamName);
         if (team == null) {
-            plugin.getLogger().warning("Team 'level_display' not found. Creating a new one.");
-            team = scoreboard.registerNewTeam("level_display");
+            team = scoreboard.registerNewTeam(teamName);
             team.setAllowFriendlyFire(true);
             team.setCanSeeFriendlyInvisibles(false);
         }
-
-        // Dodaj gracza do teamu
+        team.setPrefix(String.format("§b[ %d ] §r", level));
         team.addEntry(player.getName());
 
-        // Zaktualizuj Tab
-        player.setPlayerListName(String.format("§b[ %d ] §r%s", level, player.getName()));
+        String display = player.getName();
+        if (essentials != null) {
+            User user = essentials.getUser(player);
+            if (user != null) {
+                String nick = user.getNick();
+                if (nick != null && !nick.isEmpty()) {
+                    display = nick;
+                }
+            }
+        }
+        String formatted = String.format("§b[ %d ] §r%s", level, display);
+        player.setPlayerListName(formatted);
+        player.setCustomName(formatted);
+        player.setCustomNameVisible(true);
     }
 
     public void updateAllPlayerTabs() {
@@ -59,18 +78,14 @@ public class PlayerLevelDisplayHandler implements Listener {
         }
     }
 
-    private void setupScoreboardTeam() {
+    private void removePlayerTeam(Player player) {
         Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
         if (scoreboard == null) {
-            plugin.getLogger().warning("Scoreboard not available. Team setup skipped.");
             return;
         }
-
-        // Utwórz team "level_display", jeśli nie istnieje
-        if (scoreboard.getTeam("level_display") == null) {
-            Team team = scoreboard.registerNewTeam("level_display");
-            team.setAllowFriendlyFire(true);
-            team.setCanSeeFriendlyInvisibles(false);
+        Team team = scoreboard.getTeam("level_" + player.getName());
+        if (team != null) {
+            team.unregister();
         }
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: MyExperiencePlugin
 version: '${project.version}'
 main: com.maks.myexperienceplugin.MyExperiencePlugin
 api-version: '1.20'
+softdepend: [Essentials]
 commands:
   exp:
     description: Displays player level and experience.


### PR DESCRIPTION
## Summary
- integrate EssentialsX to display player levels alongside nicknames and above heads
- add EssentialsX repository and dependency
- declare Essentials as soft-depend

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688c63b07d04832a9bd55206635164d0