### PR TITLE
Ensure custom name survives display updates

### DIFF
--- a/src/main/java/com/maks/myexperienceplugin/exp/PlayerLevelDisplayHandler.java
+++ b/src/main/java/com/maks/myexperienceplugin/exp/PlayerLevelDisplayHandler.java
@@ -99,10 +99,14 @@ public class PlayerLevelDisplayHandler implements Listener {
         // Use nickname alone in the tab list; prefix comes from scoreboard team
         player.setPlayerListName(display);
 
-        // Show level and nick above the player's head without any rank prefix
-        player.setCustomName(String.format("§b[ %d ] §r%s", level, display));
+        // Set the player's display name first so plugins like Essentials update correctly
+        player.setDisplayName(rankPrefix + display);
 
-        player.setCustomNameVisible(true);
+        // Reapply the custom name on the next tick to ensure it isn't overwritten
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            player.setCustomName(String.format("§b[ %d ] §r%s", level, display));
+            player.setCustomNameVisible(true);
+        });
     }
 
     @EventHandler


### PR DESCRIPTION
## Summary
- Reapply player custom name on the next tick to stop Essentials from resetting it
- Set display name with rank prefix before scheduling custom name

## Testing
- `mvn test` *(fails: PluginResolutionException: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_688ddbe8c540832a89018b50b91644db