### PR TITLE
Include rank prefix in chat display

### DIFF
--- a/src/main/java/com/maks/myexperienceplugin/exp/PlayerLevelDisplayHandler.java
+++ b/src/main/java/com/maks/myexperienceplugin/exp/PlayerLevelDisplayHandler.java
@@ -96,6 +96,9 @@ public class PlayerLevelDisplayHandler implements Listener {
             display = display.substring(rankPrefix.length()).trim();
         }
 
+        // Set the player's display name so chat reflects the rank prefix
+        player.setDisplayName(rankPrefix + display);
+
         // Use nickname alone in the tab list; prefix comes from scoreboard team
         player.setPlayerListName(display);
 


### PR DESCRIPTION
## Summary
- ensure player display names include rank prefixes for chat messages

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_688ddbe758e8832ab4030cd62a6d605b