### PR TITLE
Reapply FlameWarden fire resistance after respawn

### DIFF
--- a/src/main/java/com/maks/myexperienceplugin/MyExperiencePlugin.java
+++ b/src/main/java/com/maks/myexperienceplugin/MyExperiencePlugin.java
@@ -1007,14 +1007,31 @@ public class MyExperiencePlugin extends JavaPlugin implements Listener {
                         if (skillTreeManager.getPurchasedSkills(uuid).contains(300003)) {
                             // Apply fire resistance effect
                             player.addPotionEffect(new org.bukkit.potion.PotionEffect(
-                                org.bukkit.potion.PotionEffectType.FIRE_RESISTANCE, 
+                                org.bukkit.potion.PotionEffectType.FIRE_RESISTANCE,
                                 Integer.MAX_VALUE, 0, false, false, true));
-                            getLogger().info("[FLAMEWARDEN] Applied infinite fire resistance to " + player.getName() + " on login");
                         }
                     }, 20L); // 1 second delay
                 }
             }
         }, 40L); // 2 second delay
+    }
+
+    @EventHandler
+    public void onPlayerRespawn(org.bukkit.event.player.PlayerRespawnEvent event) {
+        Player player = event.getPlayer();
+        UUID uuid = player.getUniqueId();
+        String ascendancy = classManager.getPlayerAscendancy(uuid);
+
+        if ("FlameWarden".equals(ascendancy) && ascendancySkillEffectIntegrator != null) {
+            // Reapply infinite fire resistance shortly after respawn
+            Bukkit.getScheduler().runTaskLater(this, () -> {
+                if (skillTreeManager.getPurchasedSkills(uuid).contains(300003)) {
+                    player.addPotionEffect(new org.bukkit.potion.PotionEffect(
+                        org.bukkit.potion.PotionEffectType.FIRE_RESISTANCE,
+                        Integer.MAX_VALUE, 0, false, false, true));
+                }
+            }, 20L); // 1 second delay
+        }
     }
 
     // Add this method to your MyExperiencePlugin class:


### PR DESCRIPTION
## Summary
- ensure Flame Warden players retain infinite fire resistance after death by reapplying the effect on respawn
- remove unnecessary FlameWarden debug logging
- verified other classes don't grant permanent effects that require reapplication

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e65e36bbc832aa52ffc442e9c0546