### PR TITLE
Handle multi-level skill costs correctly and ensure Java 8 compatibility

### DIFF
--- a/src/main/java/com/maks/myexperienceplugin/Class/skills/SkillPurchaseManager.java
+++ b/src/main/java/com/maks/myexperienceplugin/Class/skills/SkillPurchaseManager.java
@@ -175,7 +175,8 @@ public class SkillPurchaseManager {
                     SkillNode node = tree.getNode(nodeId);
 
                     if (node != null && purchaseCount < node.getMaxPurchases() &&
-                            skillTreeManager.getUnusedBasicSkillPoints(uuid) >= node.getCost()) {
+                            skillTreeManager.getUnusedBasicSkillPoints(uuid) >=
+                                    (node.getMaxPurchases() > 1 ? 1 : node.getCost())) {
 
                         success = skillTreeManager.purchaseSkill(player, nodeId);
 
@@ -274,7 +275,8 @@ public class SkillPurchaseManager {
                         SkillNode node = tree.getNode(nodeId);
 
                         if (node != null && purchaseCount < node.getMaxPurchases() &&
-                                skillTreeManager.getUnusedAscendancySkillPoints(uuid) >= 1) {
+                                skillTreeManager.getUnusedAscendancySkillPoints(uuid) >=
+                                        (node.getMaxPurchases() > 1 ? 1 : node.getCost())) {
 
                             success = skillTreeManager.purchaseAscendancySkill(player, nodeId);
 

--- a/src/main/java/com/maks/myexperienceplugin/Class/skills/SkillTreeManager.java
+++ b/src/main/java/com/maks/myexperienceplugin/Class/skills/SkillTreeManager.java
@@ -409,13 +409,8 @@ public class SkillTreeManager {
             if (node != null) {
                 int purchaseCount = purchaseCounts.getOrDefault(skillId, 1);
 
-                // Determine actual cost
-                int actualCost;
-                if (manager.isMultiPurchaseDiscountSkill(skillId)) {
-                    actualCost = 1; // Special skills cost 1 point per purchase
-                } else {
-                    actualCost = node.getCost();
-                }
+                // Determine actual cost (multi-level skills cost 1 point per purchase)
+                int actualCost = node.getMaxPurchases() > 1 ? 1 : node.getCost();
 
                 int skillCost = actualCost * purchaseCount;
                 usedPoints += skillCost;
@@ -472,12 +467,7 @@ public class SkillTreeManager {
                     int purchaseCount = purchaseCounts.getOrDefault(skillId, 1);
                     
                     // FIXED: Use actual node cost instead of always 1
-                    int actualCost;
-                    if (manager != null && manager.isMultiPurchaseDiscountSkill(skillId)) {
-                        actualCost = 1; // Special skills cost 1 point per purchase
-                    } else {
-                        actualCost = node.getCost(); // Use the actual cost from the node
-                    }
+                    int actualCost = node.getMaxPurchases() > 1 ? 1 : node.getCost();
                     
                     int skillCost = actualCost * purchaseCount;
                     usedPoints += skillCost;
@@ -536,12 +526,7 @@ public class SkillTreeManager {
 
         // Check if player has enough points
         int unusedPoints = getUnusedBasicSkillPoints(uuid);
-        int actualCost;
-        if (manager.isMultiPurchaseDiscountSkill(skillId)) {
-            actualCost = 1; // Special skills cost 1 point per purchase
-        } else {
-            actualCost = node.getCost();
-        }
+        int actualCost = node.getMaxPurchases() > 1 ? 1 : node.getCost();
 
         if (unusedPoints < actualCost) {
             return false;
@@ -565,12 +550,7 @@ public class SkillTreeManager {
         SkillNode node = tree.getNode(skillId);
 
         // Determine actual cost
-        int actualCost;
-        if (manager.isMultiPurchaseDiscountSkill(skillId)) {
-            actualCost = 1; // Special skills cost 1 point per purchase
-        } else {
-            actualCost = node.getCost();
-        }
+        int actualCost = node.getMaxPurchases() > 1 ? 1 : node.getCost();
 
         if (debuggingFlag == 1) {
             plugin.getLogger().info("Purchasing skill " + skillId + " for player " + player.getName());
@@ -652,12 +632,7 @@ public class SkillTreeManager {
         int unusedPoints = getUnusedAscendancySkillPoints(uuid);
         
         // FIXED: Use actual node cost instead of always 1
-        int actualCost;
-        if (manager.isMultiPurchaseDiscountSkill(skillId)) {
-            actualCost = 1; // Special skills cost 1 point per purchase
-        } else {
-            actualCost = node.getCost(); // Use the actual cost from the node
-        }
+        int actualCost = node.getMaxPurchases() > 1 ? 1 : node.getCost();
         
         if (unusedPoints < actualCost) {
             if (debuggingFlag == 1) {
@@ -714,12 +689,7 @@ public class SkillTreeManager {
         SkillNode node = tree.getNode(skillId);
 
         // Determine actual cost
-        int actualCost;
-        if (manager.isMultiPurchaseDiscountSkill(skillId)) {
-            actualCost = 1; // Special skills cost 1 point per purchase
-        } else {
-            actualCost = node.getCost();
-        }
+        int actualCost = node.getMaxPurchases() > 1 ? 1 : node.getCost();
 
         if (debuggingFlag == 1) {
             plugin.getLogger().info("Purchasing ascendancy skill " + skillId +

--- a/src/main/java/com/maks/myexperienceplugin/Class/skills/effects/ascendancy/ElementalistSkillEffectsHandler.java
+++ b/src/main/java/com/maks/myexperienceplugin/Class/skills/effects/ascendancy/ElementalistSkillEffectsHandler.java
@@ -253,7 +253,8 @@ public class ElementalistSkillEffectsHandler extends BaseSkillEffectsHandler imp
                 int durTicks = 60 + (isPurchased(playerId, ID_OFFSET + 2) ? 20 : 0);
                 long untilMs = System.currentTimeMillis() + durTicks * 50L;
                 for (Entity e : player.getWorld().getNearbyEntities(player.getLocation(), 4, 4, 4)) {
-                    if (e instanceof LivingEntity le && !le.isDead()) {
+                    if (e instanceof LivingEntity && !((LivingEntity) e).isDead()) {
+                        LivingEntity le = (LivingEntity) e;
                         UUID tid = le.getUniqueId();
                         frozenEnemies.computeIfAbsent(playerId, k -> new ConcurrentHashMap<>()).put(tid, untilMs);
                         if (isPurchased(playerId, ID_OFFSET + 5)) {
@@ -1205,7 +1206,8 @@ public class ElementalistSkillEffectsHandler extends BaseSkillEffectsHandler imp
             Location c = player.getLocation();
             plugin.getServer().getScheduler().runTask(plugin, () -> {
                 for (Entity e : c.getWorld().getNearbyEntities(c, 5, 5, 5)) {
-                    if (e instanceof LivingEntity le && !le.equals(player)) {
+                    if (e instanceof LivingEntity && !e.equals(player)) {
+                        LivingEntity le = (LivingEntity) e;
                         le.damage(base, player);
                     }
                 }

--- a/src/main/java/com/maks/myexperienceplugin/Class/skills/gui/AscendancySkillTreeGUI.java
+++ b/src/main/java/com/maks/myexperienceplugin/Class/skills/gui/AscendancySkillTreeGUI.java
@@ -848,8 +848,8 @@ public class AscendancySkillTreeGUI {
         lore.add(ChatColor.GRAY + node.getDescription());
         lore.add("");
 
-        // Use the actual cost from the skill node
-        int actualCost = node.getCost();
+        // Use the actual cost from the skill node; multi-level skills cost 1 per upgrade
+        int actualCost = node.getMaxPurchases() > 1 ? 1 : node.getCost();
 
         if (isPurchased) {
             if (purchaseCount < node.getMaxPurchases()) {


### PR DESCRIPTION
## Summary
- Fix Elementalist skill effect code to avoid Java 16 pattern matching and compile on Java 8
- Display correct 1-point cost for multi-purchase skills in ascendancy GUI and purchase checks
- Simplify skill cost calculations to treat multi-level skills as 1 point per upgrade

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a06697a740832ab7c45a70ceec813f