### PR TITLE
Expose protection reduction stats in player attributes UI

### DIFF
--- a/src/main/java/com/maks/myexperienceplugin/MyExperiencePlugin.java
+++ b/src/main/java/com/maks/myexperienceplugin/MyExperiencePlugin.java
@@ -12,6 +12,7 @@ import com.maks.myexperienceplugin.party.PartyCommand;
 import com.maks.myexperienceplugin.party.PartyManager;
 import com.maks.myexperienceplugin.party.PartyManageCommand;
 import com.maks.myexperienceplugin.tutorial.TutorialManager;
+import com.maks.myexperienceplugin.protection.ProtectionScalingService;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
@@ -65,11 +66,18 @@ public class MyExperiencePlugin extends JavaPlugin implements Listener {
     private SkillTreeGUI skillTreeGUI;
     private SkillEffectsHandler skillEffectsHandler;
     private AscendancySkillEffectIntegrator ascendancySkillEffectIntegrator;
+    private ProtectionScalingService protectionScalingService;
+
     public ClassManager getClassManager() {
         return classManager;
     }
+
     public ClassGUI getClassGUI() {
         return classGUI;
+    }
+
+    public ProtectionScalingService getProtectionScalingService() {
+        return protectionScalingService;
     }
     private AscendancySkillTreeGUI ascendancySkillTreeGUI; // Add this field
     private SkillPurchaseManager skillPurchaseManager;
@@ -160,6 +168,7 @@ public class MyExperiencePlugin extends JavaPlugin implements Listener {
         skillTreeManager = new SkillTreeManager(this);
         skillEffectsHandler = new SkillEffectsHandler(this, skillTreeManager);
         skillEffectsHandler.initializePeriodicTasks();
+        protectionScalingService = new ProtectionScalingService(this);
 
         // Initialize ascendancy skill effect integrator
         ascendancySkillEffectIntegrator = new AscendancySkillEffectIntegrator(this, skillEffectsHandler);
@@ -197,6 +206,7 @@ public class MyExperiencePlugin extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new TotemEffectListener(), this);
         getServer().getPluginManager().registerEvents(new LifestealListener(), this);
         getServer().getPluginManager().registerEvents(new ImmunityListener(), this);
+        getServer().getPluginManager().registerEvents(new ProtectionScalingListener(protectionScalingService), this);
         getServer().getPluginManager().registerEvents(new AlchemyItemListener(this, alchemyLevelConfig), this);
         getServer().getPluginManager().registerEvents(new PhysisExpListener(this), this);
 
@@ -251,7 +261,7 @@ public class MyExperiencePlugin extends JavaPlugin implements Listener {
         getCommand("skilltree").setExecutor(new SkillTreeCommand(this, skillTreeGUI));
         getCommand("skillstats").setExecutor(new SkillStatsCommand(this, skillEffectsHandler));
         getCommand("skilltree2").setExecutor(new AscendancySkillTreeCommand(this, ascendancySkillTreeGUI));
-        getCommand("playerattributes").setExecutor(new PlayerAttributesCommand(this, skillEffectsHandler));
+        getCommand("playerattributes").setExecutor(new PlayerAttributesCommand(this, skillEffectsHandler, protectionScalingService));
 
 
         // Register commands - Reset attributes
@@ -1186,5 +1196,13 @@ public class MyExperiencePlugin extends JavaPlugin implements Listener {
             }
             return false;
         });
+    }
+
+    @Override
+    public void reloadConfig() {
+        super.reloadConfig();
+        if (protectionScalingService != null) {
+            protectionScalingService.reload();
+        }
     }
 }

--- a/src/main/java/com/maks/myexperienceplugin/listener/ProtectionScalingListener.java
+++ b/src/main/java/com/maks/myexperienceplugin/listener/ProtectionScalingListener.java
@@ -1,0 +1,51 @@
+package com.maks.myexperienceplugin.listener;
+
+import com.maks.myexperienceplugin.protection.ProtectionScalingService;
+import com.maks.myexperienceplugin.protection.ProtectionScalingService.ProtectionScalingResult;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+
+public class ProtectionScalingListener implements Listener {
+
+    private final ProtectionScalingService protectionScalingService;
+
+    public ProtectionScalingListener(ProtectionScalingService protectionScalingService) {
+        this.protectionScalingService = protectionScalingService;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onEntityDamage(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof Player)) {
+            return;
+        }
+
+        Player player = (Player) event.getEntity();
+
+        if (!protectionScalingService.isEnabled()) {
+            return;
+        }
+
+        ProtectionScalingResult scalingResult = protectionScalingService.calculateFor(player);
+        if (!scalingResult.hasProtection()) {
+            return;
+        }
+
+        double vanillaMultiplier = scalingResult.safeVanillaMultiplier();
+        double finalMultiplier = scalingResult.finalMultiplier();
+        if (vanillaMultiplier <= 0.0 && finalMultiplier <= 0.0) {
+            event.setDamage(0.0);
+            return;
+        }
+
+        double ratio = scalingResult.adjustmentRatio();
+        double finalDamage = event.getDamage() * ratio;
+        if (finalDamage < 0.0) {
+            finalDamage = 0.0;
+        }
+
+        event.setDamage(finalDamage);
+    }
+}

--- a/src/main/java/com/maks/myexperienceplugin/protection/ProtectionScalingService.java
+++ b/src/main/java/com/maks/myexperienceplugin/protection/ProtectionScalingService.java
@@ -1,0 +1,202 @@
+package com.maks.myexperienceplugin.protection;
+
+import com.maks.myexperienceplugin.MyExperiencePlugin;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Centralized calculator for Protection enchantment scaling. This allows
+ * sharing the same calculations between runtime damage adjustments and
+ * presentation layers such as player stat GUIs.
+ */
+public class ProtectionScalingService {
+
+    private final MyExperiencePlugin plugin;
+
+    private boolean enabled;
+    private int baseLevel;
+    private double baseReduction;
+    private double maxCap;
+    private int maxTotalLevel;
+    private double kFactor;
+
+    public ProtectionScalingService(MyExperiencePlugin plugin) {
+        this.plugin = plugin;
+        reload();
+    }
+
+    public void reload() {
+        FileConfiguration config = plugin.getConfig();
+        enabled = config.getBoolean("protection-scaling.enabled", true);
+        baseLevel = Math.max(0, config.getInt("protection-scaling.base-level", 16));
+        baseReduction = clamp(config.getDouble("protection-scaling.base-reduction", 0.64), 0.0, 1.0);
+        maxCap = clamp(config.getDouble("protection-scaling.max-cap", 0.80), 0.0, 1.0);
+        maxTotalLevel = Math.max(0, config.getInt("protection-scaling.max-total-level", 800));
+        kFactor = Math.max(0.0, config.getDouble("protection-scaling.k-factor", 0.102));
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public ProtectionScalingResult calculateFor(Player player) {
+        if (player == null) {
+            return ProtectionScalingResult.empty();
+        }
+
+        int totalProt = 0;
+        ItemStack[] armorContents = player.getInventory().getArmorContents();
+        if (armorContents != null) {
+            for (ItemStack armor : armorContents) {
+                if (armor == null) {
+                    continue;
+                }
+                totalProt += armor.getEnchantmentLevel(Enchantment.PROTECTION_ENVIRONMENTAL);
+            }
+        }
+
+        return calculate(totalProt);
+    }
+
+    public ProtectionScalingResult calculate(int totalProtectionLevel) {
+        int rawTotal = Math.max(0, totalProtectionLevel);
+        int clampedTotal = maxTotalLevel > 0 ? Math.min(rawTotal, maxTotalLevel) : rawTotal;
+
+        int vanillaEPF = Math.min(rawTotal, 20);
+        double vanillaMultiplier = 1.0 - (vanillaEPF * 0.04);
+        if (vanillaMultiplier < 0.0) {
+            vanillaMultiplier = 0.0;
+        }
+        double vanillaReduction = clamp(1.0 - vanillaMultiplier, 0.0, 1.0);
+
+        if (!enabled || rawTotal <= 0) {
+            return new ProtectionScalingResult(
+                    rawTotal,
+                    clampedTotal,
+                    0,
+                    vanillaMultiplier,
+                    vanillaMultiplier,
+                    vanillaReduction,
+                    vanillaReduction
+            );
+        }
+
+        double baseMultiplier = 1.0;
+        if (baseLevel > 0 && baseReduction > 0.0) {
+            int baseProt = Math.min(clampedTotal, baseLevel);
+            if (baseLevel > 0) {
+                double baseRatio = (double) baseProt / (double) baseLevel;
+                baseMultiplier -= baseReduction * baseRatio;
+            }
+        }
+        baseMultiplier = clamp(baseMultiplier, 0.0, 1.0);
+
+        int extraLevels = Math.max(0, clampedTotal - baseLevel);
+        double extraMultiplier = 1.0;
+        if (extraLevels > 0 && kFactor > 0.0) {
+            extraMultiplier = 100.0 / (100.0 + kFactor * extraLevels);
+        }
+
+        double finalMultiplier = clamp(baseMultiplier * extraMultiplier, 0.0, 1.0);
+        double minMultiplier = maxCap >= 1.0 ? 0.0 : 1.0 - maxCap;
+        if (minMultiplier < 0.0) {
+            minMultiplier = 0.0;
+        }
+        if (finalMultiplier < minMultiplier) {
+            finalMultiplier = minMultiplier;
+        }
+
+        double finalReduction = clamp(1.0 - finalMultiplier, 0.0, 1.0);
+
+        return new ProtectionScalingResult(
+                rawTotal,
+                clampedTotal,
+                extraLevels,
+                vanillaMultiplier,
+                finalMultiplier,
+                vanillaReduction,
+                finalReduction
+        );
+    }
+
+    private double clamp(double value, double min, double max) {
+        if (value < min) {
+            return min;
+        }
+        return Math.min(value, max);
+    }
+
+    public static class ProtectionScalingResult {
+        private static final ProtectionScalingResult EMPTY = new ProtectionScalingResult(0, 0, 0, 1.0, 1.0, 0.0, 0.0);
+
+        private final int totalProtectionLevels;
+        private final int clampedProtectionLevels;
+        private final int extraProtectionLevels;
+        private final double vanillaMultiplier;
+        private final double finalMultiplier;
+        private final double vanillaReduction;
+        private final double finalReduction;
+
+        public ProtectionScalingResult(int totalProtectionLevels,
+                                       int clampedProtectionLevels,
+                                       int extraProtectionLevels,
+                                       double vanillaMultiplier,
+                                       double finalMultiplier,
+                                       double vanillaReduction,
+                                       double finalReduction) {
+            this.totalProtectionLevels = totalProtectionLevels;
+            this.clampedProtectionLevels = clampedProtectionLevels;
+            this.extraProtectionLevels = extraProtectionLevels;
+            this.vanillaMultiplier = vanillaMultiplier;
+            this.finalMultiplier = finalMultiplier;
+            this.vanillaReduction = vanillaReduction;
+            this.finalReduction = finalReduction;
+        }
+
+        public static ProtectionScalingResult empty() {
+            return EMPTY;
+        }
+
+        public boolean hasProtection() {
+            return totalProtectionLevels > 0;
+        }
+
+        public int totalProtectionLevels() {
+            return totalProtectionLevels;
+        }
+
+        public int clampedProtectionLevels() {
+            return clampedProtectionLevels;
+        }
+
+        public int extraProtectionLevels() {
+            return extraProtectionLevels;
+        }
+
+        public double vanillaMultiplier() {
+            return vanillaMultiplier;
+        }
+
+        public double finalMultiplier() {
+            return finalMultiplier;
+        }
+
+        public double vanillaReduction() {
+            return vanillaReduction;
+        }
+
+        public double finalReduction() {
+            return finalReduction;
+        }
+
+        public double safeVanillaMultiplier() {
+            return vanillaMultiplier <= 0.0 ? 0.0001 : vanillaMultiplier;
+        }
+
+        public double adjustmentRatio() {
+            return finalMultiplier / safeVanillaMultiplier();
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,3 +9,11 @@ Bonus_exp:
   Enabled: false # Czy event jest włączony
   Value: 100     # Procentowy wzrost doświadczenia (100 = 100% dodatkowego expa, 200 = 200% dodatkowego expa)
 
+protection-scaling:
+  enabled: true
+  base-level: 16
+  base-reduction: 0.64
+  max-cap: 0.80
+  max-total-level: 800
+  k-factor: 0.102
+

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -91,7 +91,7 @@ commands:
   playerattributes:
     description: Shows all player attributes and skill bonuses
     usage: /playerattributes
-    aliases: [pattr, attributes]
+    aliases: [pattr, attributes, player_attrib_stats]
     permission: myplugin.playerattributes
 
   resetattributes:


### PR DESCRIPTION
## Summary
- add a reusable `ProtectionScalingService` that encapsulates the configurable protection curve and supports both runtime logic and presentation
- switch the damage listener to the shared calculator and surface protection reduction details in the player attributes command output
- register `/player_attrib_stats` as an alias for the player attributes command so the GUI can be reached with the expected shortcut

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e3c3b675f4832a83e9955a717fa54b